### PR TITLE
Add support for dark mode

### DIFF
--- a/app/src/main/java/foss/cnugteren/nlweer/MainActivity.kt
+++ b/app/src/main/java/foss/cnugteren/nlweer/MainActivity.kt
@@ -66,6 +66,7 @@ class MainActivity : AppCompatActivity() {
         if (savedInstanceState == null) { // Only when the app starts for the first time
             setStartFragment()
         }
+        setAppTheme()
 
         // The floating buttons (FAB) to go to the previous/next view
         val fabPrevious: View = findViewById(R.id.fab_previous)
@@ -189,6 +190,18 @@ class MainActivity : AppCompatActivity() {
             val navGraph = navController.graph
             navGraph.startDestination = defaultViewId
             navController.graph = navGraph
+        }
+    }
+
+    // Dark mode
+    fun setAppTheme() {
+        val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(applicationContext)
+        val darkModeSetting = sharedPreferences.getString("dark_mode", "dark_mode_no")
+        if (darkModeSetting == "dark_mode_yes") {
+            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
+        }
+        else {
+            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
         }
     }
 
@@ -339,8 +352,8 @@ class MainActivity : AppCompatActivity() {
         val enableButtons = sharedPreferences.getBoolean("floating_navigation_enable", false)
 
         val fabPrevious = findViewById<View>(R.id.fab_previous)
-        fabPrevious.isVisible = enable && enableButtons
+        if (fabPrevious != null) { fabPrevious.isVisible = enable && enableButtons }
         val fabNext = findViewById<View>(R.id.fab_next)
-        fabNext.isVisible = enable && enableButtons
+        if (fabNext != null) { fabNext.isVisible = enable && enableButtons }
     }
 }

--- a/app/src/main/java/foss/cnugteren/nlweer/ui/fragments/BuienradarChartFragment.kt
+++ b/app/src/main/java/foss/cnugteren/nlweer/ui/fragments/BuienradarChartFragment.kt
@@ -87,20 +87,33 @@ class BuienradarChartFragment : Fragment() {
     }
 
     fun loadPage() {
+        val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
+        val backgroundColour = sharedPreferences.getString("background_colour", "black")
+        var textColour = Color.BLACK
+        var background = Color.WHITE
+        if (backgroundColour == "black") {
+            textColour = Color.WHITE
+            background = Color.rgb(46, 46, 46) // matches Android's dark mode colours
+        }
+
         chart = root.findViewById(R.id.buienradar_chart)
 
         // Chart styling and formatting
         chart.axisRight.isEnabled = false
         var description = Description()
+        description.textColor = textColour
         description.text = ""
         chart.description = description
         chart.setNoDataText(getString(R.string.menu_buienradar_chart_loading))
-        chart.setNoDataTextColor(Color.BLACK)
+        chart.setNoDataTextColor(textColour)
         chart.setDrawGridBackground(false)
         chart.xAxis.setDrawGridLines(false)
         chart.axisLeft.setDrawGridLines(false)
         chart.xAxis.position = XAxis.XAxisPosition.BOTTOM
-        chart.setBackgroundColor(Color.WHITE)
+        chart.xAxis.textColor = textColour
+        chart.legend.textColor = textColour
+        chart.axisLeft.textColor = textColour
+        chart.setBackgroundColor(background)
         chart.invalidate()
 
         if (latitude == null || longitude == null) {

--- a/app/src/main/java/foss/cnugteren/nlweer/ui/fragments/BuienradarChartFragment.kt
+++ b/app/src/main/java/foss/cnugteren/nlweer/ui/fragments/BuienradarChartFragment.kt
@@ -88,10 +88,10 @@ class BuienradarChartFragment : Fragment() {
 
     fun loadPage() {
         val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
-        val backgroundColour = sharedPreferences.getString("background_colour", "black")
+        val darkMode = sharedPreferences.getString("dark_mode", "dark_mode_no")
         var textColour = Color.BLACK
         var background = Color.WHITE
-        if (backgroundColour == "black") {
+        if (darkMode == "dark_mode_yes") {
             textColour = Color.WHITE
             background = Color.rgb(46, 46, 46) // matches Android's dark mode colours
         }

--- a/app/src/main/java/foss/cnugteren/nlweer/ui/fragments/SettingsFragment.kt
+++ b/app/src/main/java/foss/cnugteren/nlweer/ui/fragments/SettingsFragment.kt
@@ -30,6 +30,7 @@ class SettingsFragment : PreferenceFragmentCompat(),
         val locationProvider = findPreference<ListPreference>("location_provider")?.entry
         val language = findPreference<ListPreference>("language")?.entry
         val backgroundColour = findPreference<ListPreference>("background_colour")?.entry
+        val darkMode = findPreference<ListPreference>("dark_mode")?.entry
         val locationShape = findPreference<ListPreference>("location_shape")?.entry
         val locationColour = findPreference<ListPreference>("location_colour")?.entry
         findPreference<EditTextPreference>("location_latitude")?.summary = latString
@@ -37,6 +38,7 @@ class SettingsFragment : PreferenceFragmentCompat(),
         findPreference<ListPreference>("language")?.summary = language
         findPreference<ListPreference>("location_provider")?.summary = locationProvider
         findPreference<ListPreference>("background_colour")?.summary = backgroundColour
+        findPreference<ListPreference>("dark_mode")?.summary = darkMode
         findPreference<ListPreference>("location_shape")?.summary = locationShape
         findPreference<ListPreference>("location_colour")?.summary = locationColour
 
@@ -114,7 +116,8 @@ class SettingsFragment : PreferenceFragmentCompat(),
 
         // Retrieves the view to be able to get the nav-menu to check for visibility
         val activity = this.activity as MainActivity
-        val navView: NavigationView = activity.findViewById(R.id.nav_view)
+        val navView = activity.findViewById<NavigationView>(R.id.nav_view)
+        if (navView == null) { return }
         val menu = navView.menu
 
         // Add all the items that are currently visible in the nav menu to the list of options
@@ -150,7 +153,7 @@ class SettingsFragment : PreferenceFragmentCompat(),
             pref.summary = sharedPreferences.getString(key, "")
         }
         if (pref is ListPreference &&
-            (key == "language" || key == "background_colour" || key == "location_shape" || key == "location_colour" || key == "location_provider")) {
+            (key == "language" || key == "background_colour" || key == "dark_mode" || key == "location_shape" || key == "location_colour" || key == "location_provider")) {
             pref.summary = findPreference<ListPreference>(key)?.entry
         }
 
@@ -226,6 +229,12 @@ class SettingsFragment : PreferenceFragmentCompat(),
 
         // Toggle the location provider button
         enableDisableLocationProviderButton()
+
+        // Set dark mode
+        if (pref is ListPreference && key == "dark_mode") {
+            val activity = this.activity as MainActivity
+            activity.setAppTheme()
+        }
     }
 
     fun changeDefaultViewIfDisabled(sharedPreferences: SharedPreferences) {

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -91,6 +91,10 @@
     <string name="settings_location_shape">Forme du balise de position</string>
     <string name="settings_location_colour">Couleur du balise de position</string>
 
+    <string name="settings_dark_mode">Mode sombre</string>
+    <string name="dark_mode_no">Désactivé</string>
+    <string name="dark_mode_yes">Activé</string>
+
     <string name="settings_languages">Langue</string>
     <string name="language_system">Défaut du système</string>
 

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -92,6 +92,10 @@
     <string name="settings_location_shape">Vorm van de locatiemarker</string>
     <string name="settings_location_colour">Kleur van de locatiemarker</string>
 
+    <string name="settings_dark_mode">Donkere modus</string>
+    <string name="dark_mode_no">Uit</string>
+    <string name="dark_mode_yes">Aan</string>
+
     <string name="settings_languages">Weergavetaal</string>
     <string name="language_system">Systeemstandaard</string>
 

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -42,6 +42,16 @@
         <item>white</item>
     </string-array>
 
+    <string-array name="dark_mode_items">
+        <item>@string/dark_mode_no</item>
+        <item>@string/dark_mode_yes</item>
+    </string-array>
+
+    <string-array name="dark_mode_values">
+        <item>dark_mode_no</item>
+        <item>dark_mode_yes</item>
+    </string-array>
+
     <string-array name="location_shape_items">
         <item>@string/option_two_circles</item>
         <item>@string/option_one_circle</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -91,6 +91,10 @@
     <string name="settings_location_shape">Location marker shape</string>
     <string name="settings_location_colour">Location marker colour</string>
 
+    <string name="settings_dark_mode">App dark mode</string>
+    <string name="dark_mode_no">Disabled</string>
+    <string name="dark_mode_yes">Enabled</string>
+
     <string name="settings_languages">Display language</string>
     <string name="language_system">System default</string>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="AppTheme" parent="Theme.AppCompat.DayNight.DarkActionBar">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>

--- a/app/src/main/res/xml/fragment_settings.xml
+++ b/app/src/main/res/xml/fragment_settings.xml
@@ -107,6 +107,13 @@
             android:title="@string/settings_languages"/>
 
         <ListPreference
+            android:defaultValue="dark_mode_no"
+            android:entries="@array/dark_mode_items"
+            android:entryValues="@array/dark_mode_values"
+            android:key="dark_mode"
+            android:title="@string/settings_dark_mode"/>
+
+        <ListPreference
             android:defaultValue="black"
             android:entries="@array/background_colour_items"
             android:entryValues="@array/background_colour_values"


### PR DESCRIPTION
Add a new option in the settings to enable/disable dark-mode of the app. Also affects the rain chart graph. Resolves #30.