### PR TITLE
Fixed broken KNMI pluim display

### DIFF
--- a/app/src/main/java/foss/cnugteren/nlweer/ui/fragments/KnmiPluimFragment.kt
+++ b/app/src/main/java/foss/cnugteren/nlweer/ui/fragments/KnmiPluimFragment.kt
@@ -40,9 +40,6 @@ class WebClientKnmiPluim : WebViewClient() {
         val darkMode = sharedPreferences.getString("dark_mode", "dark_mode_no")
         if (darkMode == "dark_mode_yes") {
             view.setBackgroundColor(Color.parseColor("#2e2e2e")); // matches Android's dark mode colours
-            view.loadUrl(
-                "javascript:document.body.style.setProperty(\"color\", \"white\");"
-            );
         }
     }
 }

--- a/app/src/main/java/foss/cnugteren/nlweer/ui/fragments/KnmiPluimFragment.kt
+++ b/app/src/main/java/foss/cnugteren/nlweer/ui/fragments/KnmiPluimFragment.kt
@@ -1,5 +1,6 @@
 package foss.cnugteren.nlweer.ui.fragments
 
+import android.graphics.Color
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -7,6 +8,7 @@ import android.view.ViewGroup
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.fragment.app.Fragment
+import androidx.preference.PreferenceManager
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import foss.cnugteren.nlweer.MainActivity
 import foss.cnugteren.nlweer.R
@@ -25,14 +27,23 @@ class WebClientKnmiPluim : WebViewClient() {
     override fun onPageFinished(view: WebView, url: String) {
         view.loadUrl("javascript:(function() {" +
                 "document.getElementsByClassName('breadcrumb')[0].style.display='none';" +
+                "document.getElementsByClassName('weather-small')[0].style.display='none';" +
                 "document.getElementsByClassName('site-header')[0].style.display='none';" +
                 "document.getElementsByClassName('site-footer')[0].style.display='none';" +
                 "document.getElementsByClassName('morelinks')[0].style.display='none';" +
                 "document.getElementsByClassName('columns')[0].style.display='none';" +
-                "document.getElementsByClassName('columns')[1].style.display='none';" +
+                "document.getElementsByClassName('columns')[2].style.display='none';" +
                 "document.getElementsByClassName('columns')[3].style.display='none';" +
                 "document.getElementsByClassName('chart-legend__wrp')[0].style.display='none';" +
                 "}\n)()")
+        val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(view.context)
+        val darkMode = sharedPreferences.getString("dark_mode", "dark_mode_no")
+        if (darkMode == "dark_mode_yes") {
+            view.setBackgroundColor(Color.parseColor("#2e2e2e")); // matches Android's dark mode colours
+            view.loadUrl(
+                "javascript:document.body.style.setProperty(\"color\", \"white\");"
+            );
+        }
     }
 }
 


### PR DESCRIPTION
**Changelog:**

- Fixed broken KNMI pluim display
- Added dark background when dark mode enabled

Pluim was showing up as:
![Screenshot_20240213-142326_NLWeer](https://github.com/CNugteren/NLWeer/assets/7467080/b7252124-d26e-48c0-8d1f-e633eb4985e8)

After fixes:
![Screenshot_20240213-142232_NLWeer](https://github.com/CNugteren/NLWeer/assets/7467080/4d3f192f-e651-451a-90e3-20de389e89bc)
