### PR TITLE
Fixed 6-day forecast crash

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,6 +70,6 @@ dependencies {
     implementation 'org.jsoup:jsoup:1.17.2'
     implementation 'com.github.PhilJay:MPAndroidChart:v3.1.0'
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,7 +14,6 @@
         android:theme="@style/AppTheme">
         <activity
             android:name=".MainActivity"
-            android:label="@string/app_name"
             android:theme="@style/AppTheme.NoActionBar"
             android:exported="true">
             <intent-filter>

--- a/app/src/main/java/foss/cnugteren/nlweer/ui/fragments/KnmiSixDayForecastFragment.kt
+++ b/app/src/main/java/foss/cnugteren/nlweer/ui/fragments/KnmiSixDayForecastFragment.kt
@@ -18,6 +18,7 @@ import foss.cnugteren.nlweer.databinding.FragmentKnmiSixdayforecastBinding
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
+import java.lang.IllegalArgumentException
 import kotlin.math.ceil
 import kotlin.math.floor
 import kotlin.math.min
@@ -124,7 +125,15 @@ class KnmiSixDayForecastFragment : Fragment() {
         // Get the weather data per day of the week
         private fun getTableData(tableWrapperElement: Element) : Array<Array<String>> {
             val weatherPerDay = tableWrapperElement.select("li")
-            val tableData = Array<Array<String>>(weatherPerDay.size, { Array<String>(15, {""}) })
+            val numberOfTableCells = weatherPerDay.firstOrNull()?.select("span.weather-map__table-cell")?.size
+            if (numberOfTableCells == null) {
+                throw IllegalArgumentException("No rows with weather data found")
+            }
+            // Day of the week + date + weather icon + 2 rows for each property
+            val numberOfRows = 2 * (numberOfTableCells - 1) + 1
+            val tableData = Array<Array<String>>(weatherPerDay.size, { Array<String>(numberOfRows, {""}) })
+
+
             weatherPerDay.forEachIndexed { colIndex, column ->
                 var rowIndex = 0
 

--- a/app/src/main/java/foss/cnugteren/nlweer/ui/fragments/KnmiSixDayForecastFragment.kt
+++ b/app/src/main/java/foss/cnugteren/nlweer/ui/fragments/KnmiSixDayForecastFragment.kt
@@ -74,8 +74,7 @@ class KnmiSixDayForecastFragment : Fragment() {
 
     private fun loadPage() {
         val webView = binding.webView
-        val htmlBuilder = HtmlBuilder()
-        webView.loadData(htmlBuilder.buildHtmlPageWithLoadingMessage(), "text/html", "utf-8")
+        webView.loadData(HtmlBuilder().buildHtmlPageWithLoadingMessage(), "text/html", "utf-8")
         RetrieveWebPage().execute(getURL())
     }
 
@@ -112,9 +111,14 @@ class KnmiSixDayForecastFragment : Fragment() {
                 return
             }
 
-            val tableData = getTableData(tableWrapperElement)
-            val htmlPageToShow = htmlBuilder.buildHtmlPageWithTables(tableData)
-            webView.loadData(htmlPageToShow, "text/html", "UTF-8")
+            try {
+                val tableData = getTableData(tableWrapperElement)
+                val htmlPageToShow = htmlBuilder.buildHtmlPageWithTables(tableData)
+                webView.loadData(htmlPageToShow, "text/html", "UTF-8")
+            }
+            catch (ex: Exception) {
+                webView.loadData(htmlBuilder.buildHtmPageWithLoadingError(), "text/html", "utf-8")
+            }
         }
 
         // Get the weather data per day of the week
@@ -202,7 +206,8 @@ class KnmiSixDayForecastFragment : Fragment() {
                     var column = tableNumber * columnsPerTable
                     // Loop until either all columns for the current table have been processed,
                     // or all columns have already been processed
-                    while (column < (tableNumber + 1 ) * columnsPerTable && column < totalNumberOfColumns) {
+                    val endColumn = min((tableNumber + 1 ) * columnsPerTable, totalNumberOfColumns)
+                    while (column < endColumn) {
                         var content = tableData[column][row]
                         if (URLUtil.isValidUrl(content)) {
                             content = """<img alt="" src="""" + content + """" width="""" + imageSize + """px"/>"""

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,7 @@ android.enableJetifier=true
 kotlin.code.style=official
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
+RELEASE_STORE_FILE=~/.android/debug.keystore
+RELEASE_STORE_PASSWORD=android
+RELEASE_KEY_ALIAS=androiddebugkey
+RELEASE_KEY_PASSWORD=android


### PR DESCRIPTION
KNMI has added `Zonkracht` to the table, resulting in an index out of bounds.

**Changelog:**
- Calculate number of table rows dynamically
- Fixed build error by upgrading `androidx.test` library
- Prevent 6-day forecast crash by adding a `try/catch` block
- Add local signing config to be able to load the project locally