### PR TITLE
Fix logo cut-off in navigation drawer on some devices (e.g. Pixel 5)

### DIFF
--- a/app/src/main/res/layout/nav_header_main.xml
+++ b/app/src/main/res/layout/nav_header_main.xml
@@ -14,8 +14,8 @@
 
     <ImageView
         android:id="@+id/imageView"
-        android:layout_width="70dp"
-        android:layout_height="70dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:contentDescription="@string/nav_header_desc"
         android:paddingTop="@dimen/nav_header_vertical_spacing"
         app:srcCompat="@mipmap/ic_launcher_round" />
@@ -24,7 +24,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:paddingTop="@dimen/nav_header_vertical_spacing"
-        android:paddingStart="7dp"
         android:text="@string/nav_header_title"
         android:textAppearance="@style/TextAppearance.AppCompat.Body1" />
 
@@ -32,7 +31,6 @@
         android:id="@+id/textView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:paddingStart="7dp"
         android:text="@string/nav_header_subtitle" />
 
 </LinearLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -3,5 +3,6 @@
     <dimen name="activity_horizontal_margin">16dp</dimen>
     <dimen name="activity_vertical_margin">16dp</dimen>
     <dimen name="nav_header_vertical_spacing">8dp</dimen>
-    <dimen name="nav_header_height">176dp</dimen>
+    <!--- Increased by 30dp to fit the Pixel 5 (and likely other devices) -->
+    <dimen name="nav_header_height">206dp</dimen>
 </resources>


### PR DESCRIPTION
This should fix https://github.com/CNugteren/NLWeer/issues/61.

Interestingly, I had to deviate from the recommended sizes here. So I made a new sample Android app with the navigation drawer, all pre-filled-in by Android Studio, ran it on the Pixel 5 without modifications, and it showed the same bug.

The drawback is that on devices that didn't show this bug it uses slightly more space, but I think that is fine.

I'll do a bit more testing before merging this in.